### PR TITLE
Enable aliases when loading YAML files

### DIFF
--- a/lib/paypal-sdk/core/config.rb
+++ b/lib/paypal-sdk/core/config.rb
@@ -245,7 +245,7 @@ module PayPal::SDK::Core
       def read_configurations(file_name = "config/paypal.yml")
         erb = ERB.new(File.read(file_name))
         erb.filename = file_name
-        YAML.load(erb.result)
+        YAML.load(erb.result, aliases: true)
       end
 
     end


### PR DESCRIPTION
#### Aim

Ruby 3.1 includes Psych 4, instead of 3.

Psych 4 complains when using aliases in config if called with `YAML.load`.

Psych 4 changed YAML.load to alias YAML.safe_load instead of its previous behaviour of YAML.unsafe_load.

A bunch of gems had this issue too, eg: https://github.com/rails/rails/pull/42249/files

#### Solution

Simply pass `aliases: true` if a YAML file contains aliases (which they do in this gem, eg `default`)