### PR TITLE
Enable aliases when loading YAML files

### DIFF
--- a/lib/paypal-sdk/core/config.rb
+++ b/lib/paypal-sdk/core/config.rb
@@ -245,7 +245,7 @@ module PayPal::SDK::Core
       def read_configurations(file_name = "config/paypal.yml")
         erb = ERB.new(File.read(file_name))
         erb.filename = file_name
-        YAML.load(erb.result)
+        YAML.load(erb.result, aliases: true)
       end
 
     end


### PR DESCRIPTION
Reopening this PR because I had to revert the changes to hotfix an issue with production certificate. I couldn't have this PR merged to master because it works only with Ruby 3.1 and I needed to fix current production that was on 3.0.x

This PR is a copy of #1 